### PR TITLE
Fix GNOME Software and GNOME Calendar - Fixes #216

### DIFF
--- a/Moka/16x16/apps/org.gnome.Calendar.png
+++ b/Moka/16x16/apps/org.gnome.Calendar.png
@@ -1,0 +1,1 @@
+calendar.png

--- a/Moka/16x16/apps/org.gnome.Software.png
+++ b/Moka/16x16/apps/org.gnome.Software.png
@@ -1,0 +1,1 @@
+gnome-software.png

--- a/Moka/16x16@2x/apps/org.gnome.Calendar.png
+++ b/Moka/16x16@2x/apps/org.gnome.Calendar.png
@@ -1,0 +1,1 @@
+calendar.png

--- a/Moka/16x16@2x/apps/org.gnome.Software.png
+++ b/Moka/16x16@2x/apps/org.gnome.Software.png
@@ -1,0 +1,1 @@
+gnome-software.png

--- a/Moka/22x22/apps/org.gnome.Calendar.png
+++ b/Moka/22x22/apps/org.gnome.Calendar.png
@@ -1,0 +1,1 @@
+calendar.png

--- a/Moka/22x22/apps/org.gnome.Software.png
+++ b/Moka/22x22/apps/org.gnome.Software.png
@@ -1,0 +1,1 @@
+gnome-software.png

--- a/Moka/22x22@2x/apps/org.gnome.Calendar.png
+++ b/Moka/22x22@2x/apps/org.gnome.Calendar.png
@@ -1,0 +1,1 @@
+calendar.png

--- a/Moka/22x22@2x/apps/org.gnome.Software.png
+++ b/Moka/22x22@2x/apps/org.gnome.Software.png
@@ -1,0 +1,1 @@
+gnome-software.png

--- a/Moka/24x24/apps/org.gnome.Calendar.png
+++ b/Moka/24x24/apps/org.gnome.Calendar.png
@@ -1,0 +1,1 @@
+calendar.png

--- a/Moka/24x24/apps/org.gnome.Software.png
+++ b/Moka/24x24/apps/org.gnome.Software.png
@@ -1,0 +1,1 @@
+gnome-software.png

--- a/Moka/24x24@2x/apps/org.gnome.Calendar.png
+++ b/Moka/24x24@2x/apps/org.gnome.Calendar.png
@@ -1,0 +1,1 @@
+calendar.png

--- a/Moka/24x24@2x/apps/org.gnome.Software.png
+++ b/Moka/24x24@2x/apps/org.gnome.Software.png
@@ -1,0 +1,1 @@
+gnome-software.png

--- a/Moka/256x256/apps/org.gnome.Calendar.png
+++ b/Moka/256x256/apps/org.gnome.Calendar.png
@@ -1,0 +1,1 @@
+calendar.png

--- a/Moka/256x256/apps/org.gnome.Software.png
+++ b/Moka/256x256/apps/org.gnome.Software.png
@@ -1,0 +1,1 @@
+gnome-software.png

--- a/Moka/256x256@2x/apps/org.gnome.Calendar.png
+++ b/Moka/256x256@2x/apps/org.gnome.Calendar.png
@@ -1,0 +1,1 @@
+calendar.png

--- a/Moka/256x256@2x/apps/org.gnome.Software.png
+++ b/Moka/256x256@2x/apps/org.gnome.Software.png
@@ -1,0 +1,1 @@
+gnome-software.png

--- a/Moka/32x32/apps/org.gnome.Calendar.png
+++ b/Moka/32x32/apps/org.gnome.Calendar.png
@@ -1,0 +1,1 @@
+calendar.png

--- a/Moka/32x32/apps/org.gnome.Software.png
+++ b/Moka/32x32/apps/org.gnome.Software.png
@@ -1,0 +1,1 @@
+gnome-software.png

--- a/Moka/32x32@2x/apps/org.gnome.Calendar.png
+++ b/Moka/32x32@2x/apps/org.gnome.Calendar.png
@@ -1,0 +1,1 @@
+calendar.png

--- a/Moka/32x32@2x/apps/org.gnome.Software.png
+++ b/Moka/32x32@2x/apps/org.gnome.Software.png
@@ -1,0 +1,1 @@
+gnome-software.png

--- a/Moka/48x48/apps/org.gnome.Calendar.png
+++ b/Moka/48x48/apps/org.gnome.Calendar.png
@@ -1,0 +1,1 @@
+calendar.png

--- a/Moka/48x48/apps/org.gnome.Software.png
+++ b/Moka/48x48/apps/org.gnome.Software.png
@@ -1,0 +1,1 @@
+gnome-software.png

--- a/Moka/48x48@2x/apps/org.gnome.Calendar.png
+++ b/Moka/48x48@2x/apps/org.gnome.Calendar.png
@@ -1,0 +1,1 @@
+calendar.png

--- a/Moka/48x48@2x/apps/org.gnome.Software.png
+++ b/Moka/48x48@2x/apps/org.gnome.Software.png
@@ -1,0 +1,1 @@
+gnome-software.png

--- a/Moka/64x64/apps/org.gnome.Calendar.png
+++ b/Moka/64x64/apps/org.gnome.Calendar.png
@@ -1,0 +1,1 @@
+calendar.png

--- a/Moka/64x64/apps/org.gnome.Software.png
+++ b/Moka/64x64/apps/org.gnome.Software.png
@@ -1,0 +1,1 @@
+gnome-software.png

--- a/Moka/64x64@2x/apps/org.gnome.Calendar.png
+++ b/Moka/64x64@2x/apps/org.gnome.Calendar.png
@@ -1,0 +1,1 @@
+calendar.png

--- a/Moka/64x64@2x/apps/org.gnome.Software.png
+++ b/Moka/64x64@2x/apps/org.gnome.Software.png
@@ -1,0 +1,1 @@
+gnome-software.png

--- a/Moka/96x96/apps/org.gnome.Calendar.png
+++ b/Moka/96x96/apps/org.gnome.Calendar.png
@@ -1,0 +1,1 @@
+calendar.png

--- a/Moka/96x96/apps/org.gnome.Software.png
+++ b/Moka/96x96/apps/org.gnome.Software.png
@@ -1,0 +1,1 @@
+gnome-software.png

--- a/Moka/96x96@2x/apps/org.gnome.Calendar.png
+++ b/Moka/96x96@2x/apps/org.gnome.Calendar.png
@@ -1,0 +1,1 @@
+calendar.png

--- a/Moka/96x96@2x/apps/org.gnome.Software.png
+++ b/Moka/96x96@2x/apps/org.gnome.Software.png
@@ -1,0 +1,1 @@
+gnome-software.png


### PR DESCRIPTION
I just added `org.gnome.Software` and `org.gnome.Calendar` as symlinks to `gnome-software` and `calendar` respectively. :smile: