### PR TITLE
Add GNOME 3.32 icons

### DIFF
--- a/Moka/16x16/apps/org.gnome.Builder.png
+++ b/Moka/16x16/apps/org.gnome.Builder.png
@@ -1,0 +1,1 @@
+builder.png

--- a/Moka/16x16/apps/org.gnome.Maps.png
+++ b/Moka/16x16/apps/org.gnome.Maps.png
@@ -1,0 +1,1 @@
+gnome-maps.png

--- a/Moka/16x16/apps/org.gnome.Settings.png
+++ b/Moka/16x16/apps/org.gnome.Settings.png
@@ -1,0 +1,1 @@
+preferences-system.png

--- a/Moka/16x16/apps/org.gnome.SimpleScan.png
+++ b/Moka/16x16/apps/org.gnome.SimpleScan.png
@@ -1,0 +1,1 @@
+../devices/scanner.png

--- a/Moka/16x16/apps/org.gnome.Terminal.png
+++ b/Moka/16x16/apps/org.gnome.Terminal.png
@@ -1,0 +1,1 @@
+utilities-terminal.png

--- a/Moka/16x16/apps/org.gnome.seahorse.Application.png
+++ b/Moka/16x16/apps/org.gnome.seahorse.Application.png
@@ -1,0 +1,1 @@
+passwords.png

--- a/Moka/16x16@2x/apps/org.gnome.Builder.png
+++ b/Moka/16x16@2x/apps/org.gnome.Builder.png
@@ -1,0 +1,1 @@
+builder.png

--- a/Moka/16x16@2x/apps/org.gnome.Maps.png
+++ b/Moka/16x16@2x/apps/org.gnome.Maps.png
@@ -1,0 +1,1 @@
+gnome-maps.png

--- a/Moka/16x16@2x/apps/org.gnome.Settings.png
+++ b/Moka/16x16@2x/apps/org.gnome.Settings.png
@@ -1,0 +1,1 @@
+preferences-system.png

--- a/Moka/16x16@2x/apps/org.gnome.SimpleScan.png
+++ b/Moka/16x16@2x/apps/org.gnome.SimpleScan.png
@@ -1,0 +1,1 @@
+../devices/scanner.png

--- a/Moka/16x16@2x/apps/org.gnome.Terminal.png
+++ b/Moka/16x16@2x/apps/org.gnome.Terminal.png
@@ -1,0 +1,1 @@
+utilities-terminal.png

--- a/Moka/16x16@2x/apps/org.gnome.seahorse.Application.png
+++ b/Moka/16x16@2x/apps/org.gnome.seahorse.Application.png
@@ -1,0 +1,1 @@
+passwords.png

--- a/Moka/22x22/apps/org.gnome.Builder.png
+++ b/Moka/22x22/apps/org.gnome.Builder.png
@@ -1,0 +1,1 @@
+builder.png

--- a/Moka/22x22/apps/org.gnome.Maps.png
+++ b/Moka/22x22/apps/org.gnome.Maps.png
@@ -1,0 +1,1 @@
+gnome-maps.png

--- a/Moka/22x22/apps/org.gnome.Settings.png
+++ b/Moka/22x22/apps/org.gnome.Settings.png
@@ -1,0 +1,1 @@
+preferences-system.png

--- a/Moka/22x22/apps/org.gnome.SimpleScan.png
+++ b/Moka/22x22/apps/org.gnome.SimpleScan.png
@@ -1,0 +1,1 @@
+../devices/scanner.png

--- a/Moka/22x22/apps/org.gnome.Terminal.png
+++ b/Moka/22x22/apps/org.gnome.Terminal.png
@@ -1,0 +1,1 @@
+utilities-terminal.png

--- a/Moka/22x22/apps/org.gnome.seahorse.Application.png
+++ b/Moka/22x22/apps/org.gnome.seahorse.Application.png
@@ -1,0 +1,1 @@
+passwords.png

--- a/Moka/22x22@2x/apps/org.gnome.Builder.png
+++ b/Moka/22x22@2x/apps/org.gnome.Builder.png
@@ -1,0 +1,1 @@
+builder.png

--- a/Moka/22x22@2x/apps/org.gnome.Maps.png
+++ b/Moka/22x22@2x/apps/org.gnome.Maps.png
@@ -1,0 +1,1 @@
+gnome-maps.png

--- a/Moka/22x22@2x/apps/org.gnome.Settings.png
+++ b/Moka/22x22@2x/apps/org.gnome.Settings.png
@@ -1,0 +1,1 @@
+preferences-system.png

--- a/Moka/22x22@2x/apps/org.gnome.SimpleScan.png
+++ b/Moka/22x22@2x/apps/org.gnome.SimpleScan.png
@@ -1,0 +1,1 @@
+../devices/scanner.png

--- a/Moka/22x22@2x/apps/org.gnome.Terminal.png
+++ b/Moka/22x22@2x/apps/org.gnome.Terminal.png
@@ -1,0 +1,1 @@
+utilities-terminal.png

--- a/Moka/22x22@2x/apps/org.gnome.seahorse.Application.png
+++ b/Moka/22x22@2x/apps/org.gnome.seahorse.Application.png
@@ -1,0 +1,1 @@
+passwords.png

--- a/Moka/24x24/apps/org.gnome.Builder.png
+++ b/Moka/24x24/apps/org.gnome.Builder.png
@@ -1,0 +1,1 @@
+builder.png

--- a/Moka/24x24/apps/org.gnome.Maps.png
+++ b/Moka/24x24/apps/org.gnome.Maps.png
@@ -1,0 +1,1 @@
+gnome-maps.png

--- a/Moka/24x24/apps/org.gnome.Settings.png
+++ b/Moka/24x24/apps/org.gnome.Settings.png
@@ -1,0 +1,1 @@
+preferences-system.png

--- a/Moka/24x24/apps/org.gnome.SimpleScan.png
+++ b/Moka/24x24/apps/org.gnome.SimpleScan.png
@@ -1,0 +1,1 @@
+../devices/scanner.png

--- a/Moka/24x24/apps/org.gnome.Terminal.png
+++ b/Moka/24x24/apps/org.gnome.Terminal.png
@@ -1,0 +1,1 @@
+utilities-terminal.png

--- a/Moka/24x24/apps/org.gnome.seahorse.Application.png
+++ b/Moka/24x24/apps/org.gnome.seahorse.Application.png
@@ -1,0 +1,1 @@
+passwords.png

--- a/Moka/24x24@2x/apps/org.gnome.Builder.png
+++ b/Moka/24x24@2x/apps/org.gnome.Builder.png
@@ -1,0 +1,1 @@
+builder.png

--- a/Moka/24x24@2x/apps/org.gnome.Maps.png
+++ b/Moka/24x24@2x/apps/org.gnome.Maps.png
@@ -1,0 +1,1 @@
+gnome-maps.png

--- a/Moka/24x24@2x/apps/org.gnome.Settings.png
+++ b/Moka/24x24@2x/apps/org.gnome.Settings.png
@@ -1,0 +1,1 @@
+preferences-system.png

--- a/Moka/24x24@2x/apps/org.gnome.SimpleScan.png
+++ b/Moka/24x24@2x/apps/org.gnome.SimpleScan.png
@@ -1,0 +1,1 @@
+../devices/scanner.png

--- a/Moka/24x24@2x/apps/org.gnome.Terminal.png
+++ b/Moka/24x24@2x/apps/org.gnome.Terminal.png
@@ -1,0 +1,1 @@
+utilities-terminal.png

--- a/Moka/24x24@2x/apps/org.gnome.seahorse.Application.png
+++ b/Moka/24x24@2x/apps/org.gnome.seahorse.Application.png
@@ -1,0 +1,1 @@
+passwords.png

--- a/Moka/256x256/apps/org.gnome.Builder.png
+++ b/Moka/256x256/apps/org.gnome.Builder.png
@@ -1,0 +1,1 @@
+builder.png

--- a/Moka/256x256/apps/org.gnome.Maps.png
+++ b/Moka/256x256/apps/org.gnome.Maps.png
@@ -1,0 +1,1 @@
+gnome-maps.png

--- a/Moka/256x256/apps/org.gnome.Settings.png
+++ b/Moka/256x256/apps/org.gnome.Settings.png
@@ -1,0 +1,1 @@
+preferences-system.png

--- a/Moka/256x256/apps/org.gnome.SimpleScan.png
+++ b/Moka/256x256/apps/org.gnome.SimpleScan.png
@@ -1,0 +1,1 @@
+../devices/scanner.png

--- a/Moka/256x256/apps/org.gnome.Terminal.png
+++ b/Moka/256x256/apps/org.gnome.Terminal.png
@@ -1,0 +1,1 @@
+utilities-terminal.png

--- a/Moka/256x256/apps/org.gnome.seahorse.Application.png
+++ b/Moka/256x256/apps/org.gnome.seahorse.Application.png
@@ -1,0 +1,1 @@
+passwords.png

--- a/Moka/256x256@2x/apps/org.gnome.Builder.png
+++ b/Moka/256x256@2x/apps/org.gnome.Builder.png
@@ -1,0 +1,1 @@
+builder.png

--- a/Moka/256x256@2x/apps/org.gnome.Maps.png
+++ b/Moka/256x256@2x/apps/org.gnome.Maps.png
@@ -1,0 +1,1 @@
+gnome-maps.png

--- a/Moka/256x256@2x/apps/org.gnome.Settings.png
+++ b/Moka/256x256@2x/apps/org.gnome.Settings.png
@@ -1,0 +1,1 @@
+preferences-system.png

--- a/Moka/256x256@2x/apps/org.gnome.SimpleScan.png
+++ b/Moka/256x256@2x/apps/org.gnome.SimpleScan.png
@@ -1,0 +1,1 @@
+../devices/scanner.png

--- a/Moka/256x256@2x/apps/org.gnome.Terminal.png
+++ b/Moka/256x256@2x/apps/org.gnome.Terminal.png
@@ -1,0 +1,1 @@
+utilities-terminal.png

--- a/Moka/256x256@2x/apps/org.gnome.seahorse.Application.png
+++ b/Moka/256x256@2x/apps/org.gnome.seahorse.Application.png
@@ -1,0 +1,1 @@
+passwords.png

--- a/Moka/32x32/apps/org.gnome.Builder.png
+++ b/Moka/32x32/apps/org.gnome.Builder.png
@@ -1,0 +1,1 @@
+builder.png

--- a/Moka/32x32/apps/org.gnome.Maps.png
+++ b/Moka/32x32/apps/org.gnome.Maps.png
@@ -1,0 +1,1 @@
+gnome-maps.png

--- a/Moka/32x32/apps/org.gnome.Settings.png
+++ b/Moka/32x32/apps/org.gnome.Settings.png
@@ -1,0 +1,1 @@
+preferences-system.png

--- a/Moka/32x32/apps/org.gnome.SimpleScan.png
+++ b/Moka/32x32/apps/org.gnome.SimpleScan.png
@@ -1,0 +1,1 @@
+../devices/scanner.png

--- a/Moka/32x32/apps/org.gnome.Terminal.png
+++ b/Moka/32x32/apps/org.gnome.Terminal.png
@@ -1,0 +1,1 @@
+utilities-terminal.png

--- a/Moka/32x32/apps/org.gnome.seahorse.Application.png
+++ b/Moka/32x32/apps/org.gnome.seahorse.Application.png
@@ -1,0 +1,1 @@
+passwords.png

--- a/Moka/32x32@2x/apps/org.gnome.Builder.png
+++ b/Moka/32x32@2x/apps/org.gnome.Builder.png
@@ -1,0 +1,1 @@
+builder.png

--- a/Moka/32x32@2x/apps/org.gnome.Maps.png
+++ b/Moka/32x32@2x/apps/org.gnome.Maps.png
@@ -1,0 +1,1 @@
+gnome-maps.png

--- a/Moka/32x32@2x/apps/org.gnome.Settings.png
+++ b/Moka/32x32@2x/apps/org.gnome.Settings.png
@@ -1,0 +1,1 @@
+preferences-system.png

--- a/Moka/32x32@2x/apps/org.gnome.SimpleScan.png
+++ b/Moka/32x32@2x/apps/org.gnome.SimpleScan.png
@@ -1,0 +1,1 @@
+../devices/scanner.png

--- a/Moka/32x32@2x/apps/org.gnome.Terminal.png
+++ b/Moka/32x32@2x/apps/org.gnome.Terminal.png
@@ -1,0 +1,1 @@
+utilities-terminal.png

--- a/Moka/32x32@2x/apps/org.gnome.seahorse.Application.png
+++ b/Moka/32x32@2x/apps/org.gnome.seahorse.Application.png
@@ -1,0 +1,1 @@
+passwords.png

--- a/Moka/48x48/apps/org.gnome.Builder.png
+++ b/Moka/48x48/apps/org.gnome.Builder.png
@@ -1,0 +1,1 @@
+builder.png

--- a/Moka/48x48/apps/org.gnome.Maps.png
+++ b/Moka/48x48/apps/org.gnome.Maps.png
@@ -1,0 +1,1 @@
+gnome-maps.png

--- a/Moka/48x48/apps/org.gnome.Settings.png
+++ b/Moka/48x48/apps/org.gnome.Settings.png
@@ -1,0 +1,1 @@
+preferences-system.png

--- a/Moka/48x48/apps/org.gnome.SimpleScan.png
+++ b/Moka/48x48/apps/org.gnome.SimpleScan.png
@@ -1,0 +1,1 @@
+../devices/scanner.png

--- a/Moka/48x48/apps/org.gnome.Terminal.png
+++ b/Moka/48x48/apps/org.gnome.Terminal.png
@@ -1,0 +1,1 @@
+utilities-terminal.png

--- a/Moka/48x48/apps/org.gnome.seahorse.Application.png
+++ b/Moka/48x48/apps/org.gnome.seahorse.Application.png
@@ -1,0 +1,1 @@
+passwords.png

--- a/Moka/48x48@2x/apps/org.gnome.Builder.png
+++ b/Moka/48x48@2x/apps/org.gnome.Builder.png
@@ -1,0 +1,1 @@
+builder.png

--- a/Moka/48x48@2x/apps/org.gnome.Maps.png
+++ b/Moka/48x48@2x/apps/org.gnome.Maps.png
@@ -1,0 +1,1 @@
+gnome-maps.png

--- a/Moka/48x48@2x/apps/org.gnome.Settings.png
+++ b/Moka/48x48@2x/apps/org.gnome.Settings.png
@@ -1,0 +1,1 @@
+preferences-system.png

--- a/Moka/48x48@2x/apps/org.gnome.SimpleScan.png
+++ b/Moka/48x48@2x/apps/org.gnome.SimpleScan.png
@@ -1,0 +1,1 @@
+../devices/scanner.png

--- a/Moka/48x48@2x/apps/org.gnome.Terminal.png
+++ b/Moka/48x48@2x/apps/org.gnome.Terminal.png
@@ -1,0 +1,1 @@
+utilities-terminal.png

--- a/Moka/48x48@2x/apps/org.gnome.seahorse.Application.png
+++ b/Moka/48x48@2x/apps/org.gnome.seahorse.Application.png
@@ -1,0 +1,1 @@
+passwords.png

--- a/Moka/64x64/apps/org.gnome.Builder.png
+++ b/Moka/64x64/apps/org.gnome.Builder.png
@@ -1,0 +1,1 @@
+builder.png

--- a/Moka/64x64/apps/org.gnome.Maps.png
+++ b/Moka/64x64/apps/org.gnome.Maps.png
@@ -1,0 +1,1 @@
+gnome-maps.png

--- a/Moka/64x64/apps/org.gnome.Settings.png
+++ b/Moka/64x64/apps/org.gnome.Settings.png
@@ -1,0 +1,1 @@
+preferences-system.png

--- a/Moka/64x64/apps/org.gnome.SimpleScan.png
+++ b/Moka/64x64/apps/org.gnome.SimpleScan.png
@@ -1,0 +1,1 @@
+../devices/scanner.png

--- a/Moka/64x64/apps/org.gnome.Terminal.png
+++ b/Moka/64x64/apps/org.gnome.Terminal.png
@@ -1,0 +1,1 @@
+utilities-terminal.png

--- a/Moka/64x64/apps/org.gnome.seahorse.Application.png
+++ b/Moka/64x64/apps/org.gnome.seahorse.Application.png
@@ -1,0 +1,1 @@
+passwords.png

--- a/Moka/64x64@2x/apps/org.gnome.Builder.png
+++ b/Moka/64x64@2x/apps/org.gnome.Builder.png
@@ -1,0 +1,1 @@
+builder.png

--- a/Moka/64x64@2x/apps/org.gnome.Maps.png
+++ b/Moka/64x64@2x/apps/org.gnome.Maps.png
@@ -1,0 +1,1 @@
+gnome-maps.png

--- a/Moka/64x64@2x/apps/org.gnome.Settings.png
+++ b/Moka/64x64@2x/apps/org.gnome.Settings.png
@@ -1,0 +1,1 @@
+preferences-system.png

--- a/Moka/64x64@2x/apps/org.gnome.SimpleScan.png
+++ b/Moka/64x64@2x/apps/org.gnome.SimpleScan.png
@@ -1,0 +1,1 @@
+../devices/scanner.png

--- a/Moka/64x64@2x/apps/org.gnome.Terminal.png
+++ b/Moka/64x64@2x/apps/org.gnome.Terminal.png
@@ -1,0 +1,1 @@
+utilities-terminal.png

--- a/Moka/64x64@2x/apps/org.gnome.seahorse.Application.png
+++ b/Moka/64x64@2x/apps/org.gnome.seahorse.Application.png
@@ -1,0 +1,1 @@
+passwords.png

--- a/Moka/8x8/emblems/emblem-danger.png
+++ b/Moka/8x8/emblems/emblem-danger.png
@@ -1,0 +1,1 @@
+emblem-important.png

--- a/Moka/8x8/emblems/emblem-insync-des-error.png
+++ b/Moka/8x8/emblems/emblem-insync-des-error.png
@@ -1,0 +1,1 @@
+emblem-important.png

--- a/Moka/8x8@2x/emblems/emblem-danger.png
+++ b/Moka/8x8@2x/emblems/emblem-danger.png
@@ -1,0 +1,1 @@
+emblem-important.png

--- a/Moka/8x8@2x/emblems/emblem-insync-des-error.png
+++ b/Moka/8x8@2x/emblems/emblem-insync-des-error.png
@@ -1,0 +1,1 @@
+emblem-important.png

--- a/Moka/96x96/apps/org.gnome.Builder.png
+++ b/Moka/96x96/apps/org.gnome.Builder.png
@@ -1,0 +1,1 @@
+builder.png

--- a/Moka/96x96/apps/org.gnome.Maps.png
+++ b/Moka/96x96/apps/org.gnome.Maps.png
@@ -1,0 +1,1 @@
+gnome-maps.png

--- a/Moka/96x96/apps/org.gnome.Settings.png
+++ b/Moka/96x96/apps/org.gnome.Settings.png
@@ -1,0 +1,1 @@
+preferences-system.png

--- a/Moka/96x96/apps/org.gnome.SimpleScan.png
+++ b/Moka/96x96/apps/org.gnome.SimpleScan.png
@@ -1,0 +1,1 @@
+../devices/scanner.png

--- a/Moka/96x96/apps/org.gnome.Terminal.png
+++ b/Moka/96x96/apps/org.gnome.Terminal.png
@@ -1,0 +1,1 @@
+utilities-terminal.png

--- a/Moka/96x96/apps/org.gnome.seahorse.Application.png
+++ b/Moka/96x96/apps/org.gnome.seahorse.Application.png
@@ -1,0 +1,1 @@
+passwords.png

--- a/Moka/96x96@2x/apps/org.gnome.Builder.png
+++ b/Moka/96x96@2x/apps/org.gnome.Builder.png
@@ -1,0 +1,1 @@
+builder.png

--- a/Moka/96x96@2x/apps/org.gnome.Maps.png
+++ b/Moka/96x96@2x/apps/org.gnome.Maps.png
@@ -1,0 +1,1 @@
+gnome-maps.png

--- a/Moka/96x96@2x/apps/org.gnome.Settings.png
+++ b/Moka/96x96@2x/apps/org.gnome.Settings.png
@@ -1,0 +1,1 @@
+preferences-system.png

--- a/Moka/96x96@2x/apps/org.gnome.SimpleScan.png
+++ b/Moka/96x96@2x/apps/org.gnome.SimpleScan.png
@@ -1,0 +1,1 @@
+../devices/scanner.png

--- a/Moka/96x96@2x/apps/org.gnome.Terminal.png
+++ b/Moka/96x96@2x/apps/org.gnome.Terminal.png
@@ -1,0 +1,1 @@
+utilities-terminal.png

--- a/Moka/96x96@2x/apps/org.gnome.seahorse.Application.png
+++ b/Moka/96x96@2x/apps/org.gnome.seahorse.Application.png
@@ -1,0 +1,1 @@
+passwords.png

--- a/src/symlinks/bitmaps/apps.list
+++ b/src/symlinks/bitmaps/apps.list
@@ -529,6 +529,7 @@ panel.png tint2conf.png
 passwords.png 1password.png
 passwords.png enpass.png
 passwords.png gnome-encfs-manager.png
+passwords.png org.gnome.seahorse.Application.png
 passwords.png password.png
 passwords.png preferences-desktop-user-password.png
 passwords.png revelation.png
@@ -650,6 +651,7 @@ preferences-system.png configuration_section.png
 preferences-system.png cs-cat-prefs.png
 preferences-system.png cs-general.png
 preferences-system.png gtk-preferences.png
+preferences-system.png org.gnome.Settings.png
 preferences-system.png system-settings.png
 preferences-system.png v4l2ucp.png
 psensor.png Psensor_normal.png
@@ -668,6 +670,7 @@ remote-desktop.png NoMachine.png
 remote-desktop.png preferences-desktop-remote-desktop.png
 remote-desktop.png remmina.png
 samba.png system-config-samba.png
+../devices/scanner.png org.gnome.SimpleScan.png
 screenruler.png screenruler-icon.png
 selinux.png setroubleshoot_icon.png
 selinux.png system-config-selinux.png
@@ -795,6 +798,7 @@ utilities-terminal.png gnome-eterm.png
 utilities-terminal.png gnome-xterm.png
 utilities-terminal.png lxterminal.png
 utilities-terminal.png openterm.png
+utilities-terminal.png org.gnome.Terminal.png
 utilities-terminal.png qterminal.png
 utilities-terminal.png terminal-tango.png
 utilities-terminal.png terra.png


### PR DESCRIPTION
After upgrading to GNOME 3.32 I noticed a couple of missing icons, seems like the `Icon` value in their `.desktop` file has changed. So I added the missing ones.

I ran the `generate-symlinks.sh` script after adding them to `apps.list ` and included those changes in this PR as well. It seems like that's the correct way of doing these updates?

P.S. when running the `generate-symlinks.sh` script from current master it generated icons for GNOME Maps and Builder, seems like the script wasn't run for those changes? I've added them as a separate commit.