### PR TITLE
Add symlink for celluloid

### DIFF
--- a/Moka/16x16/apps/io.github.celluloid_player.Celluloid.png
+++ b/Moka/16x16/apps/io.github.celluloid_player.Celluloid.png
@@ -1,0 +1,1 @@
+gnome-mpv.png

--- a/Moka/16x16@2x/apps/io.github.celluloid_player.Celluloid.png
+++ b/Moka/16x16@2x/apps/io.github.celluloid_player.Celluloid.png
@@ -1,0 +1,1 @@
+gnome-mpv.png

--- a/Moka/22x22/apps/io.github.celluloid_player.Celluloid.png
+++ b/Moka/22x22/apps/io.github.celluloid_player.Celluloid.png
@@ -1,0 +1,1 @@
+gnome-mpv.png

--- a/Moka/22x22@2x/apps/io.github.celluloid_player.Celluloid.png
+++ b/Moka/22x22@2x/apps/io.github.celluloid_player.Celluloid.png
@@ -1,0 +1,1 @@
+gnome-mpv.png

--- a/Moka/24x24/apps/io.github.celluloid_player.Celluloid.png
+++ b/Moka/24x24/apps/io.github.celluloid_player.Celluloid.png
@@ -1,0 +1,1 @@
+gnome-mpv.png

--- a/Moka/24x24@2x/apps/io.github.celluloid_player.Celluloid.png
+++ b/Moka/24x24@2x/apps/io.github.celluloid_player.Celluloid.png
@@ -1,0 +1,1 @@
+gnome-mpv.png

--- a/Moka/256x256/apps/io.github.celluloid_player.Celluloid.png
+++ b/Moka/256x256/apps/io.github.celluloid_player.Celluloid.png
@@ -1,0 +1,1 @@
+gnome-mpv.png

--- a/Moka/256x256@2x/apps/io.github.celluloid_player.Celluloid.png
+++ b/Moka/256x256@2x/apps/io.github.celluloid_player.Celluloid.png
@@ -1,0 +1,1 @@
+gnome-mpv.png

--- a/Moka/32x32/apps/io.github.celluloid_player.Celluloid.png
+++ b/Moka/32x32/apps/io.github.celluloid_player.Celluloid.png
@@ -1,0 +1,1 @@
+gnome-mpv.png

--- a/Moka/32x32@2x/apps/io.github.celluloid_player.Celluloid.png
+++ b/Moka/32x32@2x/apps/io.github.celluloid_player.Celluloid.png
@@ -1,0 +1,1 @@
+gnome-mpv.png

--- a/Moka/48x48/apps/io.github.celluloid_player.Celluloid.png
+++ b/Moka/48x48/apps/io.github.celluloid_player.Celluloid.png
@@ -1,0 +1,1 @@
+gnome-mpv.png

--- a/Moka/48x48@2x/apps/io.github.celluloid_player.Celluloid.png
+++ b/Moka/48x48@2x/apps/io.github.celluloid_player.Celluloid.png
@@ -1,0 +1,1 @@
+gnome-mpv.png

--- a/Moka/64x64/apps/io.github.celluloid_player.Celluloid.png
+++ b/Moka/64x64/apps/io.github.celluloid_player.Celluloid.png
@@ -1,0 +1,1 @@
+gnome-mpv.png

--- a/Moka/64x64@2x/apps/io.github.celluloid_player.Celluloid.png
+++ b/Moka/64x64@2x/apps/io.github.celluloid_player.Celluloid.png
@@ -1,0 +1,1 @@
+gnome-mpv.png

--- a/Moka/96x96/apps/io.github.celluloid_player.Celluloid.png
+++ b/Moka/96x96/apps/io.github.celluloid_player.Celluloid.png
@@ -1,0 +1,1 @@
+gnome-mpv.png

--- a/Moka/96x96@2x/apps/io.github.celluloid_player.Celluloid.png
+++ b/Moka/96x96@2x/apps/io.github.celluloid_player.Celluloid.png
@@ -1,0 +1,1 @@
+gnome-mpv.png

--- a/src/symlinks/bitmaps/apps.list
+++ b/src/symlinks/bitmaps/apps.list
@@ -276,6 +276,7 @@ gnome-games.png org.gnome.Games.png
 gnome-klotski.png gnotski.png
 gnome-maps.png org.gnome.Maps.png
 gnome-mpv.png io.github.GnomeMpv.png
+gnome-mpv.png io.github.celluloid_player.Celluloid.png
 gnome-music.png org.gnome.Music.png
 gnome-nettool.png nmap_icon.png
 gnome-nettool.png zenmap.png


### PR DESCRIPTION
celluloid is the new name for gnome-mpv.

This PR adds a symlink for the existing gnome-mpv icon

Tested on Ubuntu Budgie 20.04 celluloid v0.18