### PR TITLE
Add symlink for rhythmbox 3.4.4 icon name

### DIFF
--- a/Moka/16x16/apps/org.gnome.Rhythmbox.png
+++ b/Moka/16x16/apps/org.gnome.Rhythmbox.png
@@ -1,0 +1,1 @@
+rhythmbox.png

--- a/Moka/16x16@2x/apps/org.gnome.Rhythmbox.png
+++ b/Moka/16x16@2x/apps/org.gnome.Rhythmbox.png
@@ -1,0 +1,1 @@
+rhythmbox.png

--- a/Moka/22x22/apps/org.gnome.Rhythmbox.png
+++ b/Moka/22x22/apps/org.gnome.Rhythmbox.png
@@ -1,0 +1,1 @@
+rhythmbox.png

--- a/Moka/22x22@2x/apps/org.gnome.Rhythmbox.png
+++ b/Moka/22x22@2x/apps/org.gnome.Rhythmbox.png
@@ -1,0 +1,1 @@
+rhythmbox.png

--- a/Moka/24x24/apps/org.gnome.Rhythmbox.png
+++ b/Moka/24x24/apps/org.gnome.Rhythmbox.png
@@ -1,0 +1,1 @@
+rhythmbox.png

--- a/Moka/24x24@2x/apps/org.gnome.Rhythmbox.png
+++ b/Moka/24x24@2x/apps/org.gnome.Rhythmbox.png
@@ -1,0 +1,1 @@
+rhythmbox.png

--- a/Moka/256x256/apps/org.gnome.Rhythmbox.png
+++ b/Moka/256x256/apps/org.gnome.Rhythmbox.png
@@ -1,0 +1,1 @@
+rhythmbox.png

--- a/Moka/256x256@2x/apps/org.gnome.Rhythmbox.png
+++ b/Moka/256x256@2x/apps/org.gnome.Rhythmbox.png
@@ -1,0 +1,1 @@
+rhythmbox.png

--- a/Moka/32x32/apps/org.gnome.Rhythmbox.png
+++ b/Moka/32x32/apps/org.gnome.Rhythmbox.png
@@ -1,0 +1,1 @@
+rhythmbox.png

--- a/Moka/32x32@2x/apps/org.gnome.Rhythmbox.png
+++ b/Moka/32x32@2x/apps/org.gnome.Rhythmbox.png
@@ -1,0 +1,1 @@
+rhythmbox.png

--- a/Moka/48x48/apps/org.gnome.Rhythmbox.png
+++ b/Moka/48x48/apps/org.gnome.Rhythmbox.png
@@ -1,0 +1,1 @@
+rhythmbox.png

--- a/Moka/48x48@2x/apps/org.gnome.Rhythmbox.png
+++ b/Moka/48x48@2x/apps/org.gnome.Rhythmbox.png
@@ -1,0 +1,1 @@
+rhythmbox.png

--- a/Moka/64x64/apps/org.gnome.Rhythmbox.png
+++ b/Moka/64x64/apps/org.gnome.Rhythmbox.png
@@ -1,0 +1,1 @@
+rhythmbox.png

--- a/Moka/64x64@2x/apps/org.gnome.Rhythmbox.png
+++ b/Moka/64x64@2x/apps/org.gnome.Rhythmbox.png
@@ -1,0 +1,1 @@
+rhythmbox.png

--- a/Moka/96x96/apps/org.gnome.Rhythmbox.png
+++ b/Moka/96x96/apps/org.gnome.Rhythmbox.png
@@ -1,0 +1,1 @@
+rhythmbox.png

--- a/Moka/96x96@2x/apps/org.gnome.Rhythmbox.png
+++ b/Moka/96x96@2x/apps/org.gnome.Rhythmbox.png
@@ -1,0 +1,1 @@
+rhythmbox.png

--- a/src/symlinks/bitmaps/apps.list
+++ b/src/symlinks/bitmaps/apps.list
@@ -667,6 +667,7 @@ remote-desktop.png gnome-remote-desktop.png
 remote-desktop.png NoMachine.png
 remote-desktop.png preferences-desktop-remote-desktop.png
 remote-desktop.png remmina.png
+rhythmbox.png org.gnome.Rhythmbox.png
 samba.png system-config-samba.png
 screenruler.png screenruler-icon.png
 selinux.png setroubleshoot_icon.png


### PR DESCRIPTION
rhythmbox has changed its icon name to the same org.gnome convention as other GNOME based apps.

This PR adds a symlink for the existing rhythmbox icon

Tested on Ubuntu Budgie 20.04 rhythmbox 3.4.4