### PR TITLE
Symlinks for org.xfce.catfish

### DIFF
--- a/Moka/16x16/apps/org.xfce.catfish.png
+++ b/Moka/16x16/apps/org.xfce.catfish.png
@@ -1,0 +1,1 @@
+preferences-system-search.png

--- a/Moka/16x16@2x/apps/org.xfce.catfish.png
+++ b/Moka/16x16@2x/apps/org.xfce.catfish.png
@@ -1,0 +1,1 @@
+preferences-system-search.png

--- a/Moka/22x22/apps/org.xfce.catfish.png
+++ b/Moka/22x22/apps/org.xfce.catfish.png
@@ -1,0 +1,1 @@
+preferences-system-search.png

--- a/Moka/22x22@2x/apps/org.xfce.catfish.png
+++ b/Moka/22x22@2x/apps/org.xfce.catfish.png
@@ -1,0 +1,1 @@
+preferences-system-search.png

--- a/Moka/24x24/apps/org.xfce.catfish.png
+++ b/Moka/24x24/apps/org.xfce.catfish.png
@@ -1,0 +1,1 @@
+preferences-system-search.png

--- a/Moka/24x24@2x/apps/org.xfce.catfish.png
+++ b/Moka/24x24@2x/apps/org.xfce.catfish.png
@@ -1,0 +1,1 @@
+preferences-system-search.png

--- a/Moka/256x256/apps/org.xfce.catfish.png
+++ b/Moka/256x256/apps/org.xfce.catfish.png
@@ -1,0 +1,1 @@
+preferences-system-search.png

--- a/Moka/256x256@2x/apps/org.xfce.catfish.png
+++ b/Moka/256x256@2x/apps/org.xfce.catfish.png
@@ -1,0 +1,1 @@
+preferences-system-search.png

--- a/Moka/32x32/apps/org.xfce.catfish.png
+++ b/Moka/32x32/apps/org.xfce.catfish.png
@@ -1,0 +1,1 @@
+preferences-system-search.png

--- a/Moka/32x32@2x/apps/org.xfce.catfish.png
+++ b/Moka/32x32@2x/apps/org.xfce.catfish.png
@@ -1,0 +1,1 @@
+preferences-system-search.png

--- a/Moka/48x48/apps/org.xfce.catfish.png
+++ b/Moka/48x48/apps/org.xfce.catfish.png
@@ -1,0 +1,1 @@
+preferences-system-search.png

--- a/Moka/48x48@2x/apps/org.xfce.catfish.png
+++ b/Moka/48x48@2x/apps/org.xfce.catfish.png
@@ -1,0 +1,1 @@
+preferences-system-search.png

--- a/Moka/64x64/apps/org.xfce.catfish.png
+++ b/Moka/64x64/apps/org.xfce.catfish.png
@@ -1,0 +1,1 @@
+preferences-system-search.png

--- a/Moka/64x64@2x/apps/org.xfce.catfish.png
+++ b/Moka/64x64@2x/apps/org.xfce.catfish.png
@@ -1,0 +1,1 @@
+preferences-system-search.png

--- a/Moka/96x96/apps/org.xfce.catfish.png
+++ b/Moka/96x96/apps/org.xfce.catfish.png
@@ -1,0 +1,1 @@
+preferences-system-search.png

--- a/Moka/96x96@2x/apps/org.xfce.catfish.png
+++ b/Moka/96x96@2x/apps/org.xfce.catfish.png
@@ -1,0 +1,1 @@
+preferences-system-search.png

--- a/src/symlinks/bitmaps/apps.list
+++ b/src/symlinks/bitmaps/apps.list
@@ -624,6 +624,7 @@ preferences-system-power.png xfpm-ac-adapter.png
 preferences-system-privacy.png activity-log-manager.png
 preferences-system-privacy.png cs-privacy.png
 preferences-system-search.png catfish.png
+preferences-system-search.png org.xfce.catfish.png
 preferences-system-search.png recoll.png
 preferences-system-search.png search.png
 preferences-system-search.png system-search.png


### PR DESCRIPTION
catfish has a new icon name for ubuntu 21.04