### PR TITLE
Symlinks for new icon-name for gthumb

### DIFF
--- a/Moka/16x16/apps/org.gnome.gThumb.png
+++ b/Moka/16x16/apps/org.gnome.gThumb.png
@@ -1,0 +1,1 @@
+multimedia-photo-viewer.png

--- a/Moka/16x16@2x/apps/org.gnome.gThumb.png
+++ b/Moka/16x16@2x/apps/org.gnome.gThumb.png
@@ -1,0 +1,1 @@
+multimedia-photo-viewer.png

--- a/Moka/22x22/apps/org.gnome.gThumb.png
+++ b/Moka/22x22/apps/org.gnome.gThumb.png
@@ -1,0 +1,1 @@
+multimedia-photo-viewer.png

--- a/Moka/22x22@2x/apps/org.gnome.gThumb.png
+++ b/Moka/22x22@2x/apps/org.gnome.gThumb.png
@@ -1,0 +1,1 @@
+multimedia-photo-viewer.png

--- a/Moka/24x24/apps/org.gnome.gThumb.png
+++ b/Moka/24x24/apps/org.gnome.gThumb.png
@@ -1,0 +1,1 @@
+multimedia-photo-viewer.png

--- a/Moka/24x24@2x/apps/org.gnome.gThumb.png
+++ b/Moka/24x24@2x/apps/org.gnome.gThumb.png
@@ -1,0 +1,1 @@
+multimedia-photo-viewer.png

--- a/Moka/256x256/apps/org.gnome.gThumb.png
+++ b/Moka/256x256/apps/org.gnome.gThumb.png
@@ -1,0 +1,1 @@
+multimedia-photo-viewer.png

--- a/Moka/256x256@2x/apps/org.gnome.gThumb.png
+++ b/Moka/256x256@2x/apps/org.gnome.gThumb.png
@@ -1,0 +1,1 @@
+multimedia-photo-viewer.png

--- a/Moka/32x32/apps/org.gnome.gThumb.png
+++ b/Moka/32x32/apps/org.gnome.gThumb.png
@@ -1,0 +1,1 @@
+multimedia-photo-viewer.png

--- a/Moka/32x32@2x/apps/org.gnome.gThumb.png
+++ b/Moka/32x32@2x/apps/org.gnome.gThumb.png
@@ -1,0 +1,1 @@
+multimedia-photo-viewer.png

--- a/Moka/48x48/apps/org.gnome.gThumb.png
+++ b/Moka/48x48/apps/org.gnome.gThumb.png
@@ -1,0 +1,1 @@
+multimedia-photo-viewer.png

--- a/Moka/48x48@2x/apps/org.gnome.gThumb.png
+++ b/Moka/48x48@2x/apps/org.gnome.gThumb.png
@@ -1,0 +1,1 @@
+multimedia-photo-viewer.png

--- a/Moka/64x64/apps/org.gnome.gThumb.png
+++ b/Moka/64x64/apps/org.gnome.gThumb.png
@@ -1,0 +1,1 @@
+multimedia-photo-viewer.png

--- a/Moka/64x64@2x/apps/org.gnome.gThumb.png
+++ b/Moka/64x64@2x/apps/org.gnome.gThumb.png
@@ -1,0 +1,1 @@
+multimedia-photo-viewer.png

--- a/Moka/96x96/apps/org.gnome.gThumb.png
+++ b/Moka/96x96/apps/org.gnome.gThumb.png
@@ -1,0 +1,1 @@
+multimedia-photo-viewer.png

--- a/Moka/96x96@2x/apps/org.gnome.gThumb.png
+++ b/Moka/96x96@2x/apps/org.gnome.gThumb.png
@@ -1,0 +1,1 @@
+multimedia-photo-viewer.png

--- a/src/symlinks/bitmaps/apps.list
+++ b/src/symlinks/bitmaps/apps.list
@@ -485,6 +485,7 @@ multimedia-photo-viewer.png org.gnome.eog.png
 multimedia-photo-viewer.png ristretto.png
 multimedia-photo-viewer.png showfoto.png
 multimedia-photo-viewer.png showphoto.png
+multimedia-photo-viewer.png org.gnome.gThumb.png
 multimedia-video-player.png audience.png
 multimedia-video-player.png bino.png
 multimedia-video-player.png dragonplayer.png


### PR DESCRIPTION
symlinks for new gthumb icon name in ubuntu 21.04