### PR TITLE
Symlink for new name for Remmina

### DIFF
--- a/Moka/16x16/apps/org.remmina.Remmina.png
+++ b/Moka/16x16/apps/org.remmina.Remmina.png
@@ -1,0 +1,1 @@
+remote-desktop.png

--- a/Moka/16x16@2x/apps/org.remmina.Remmina.png
+++ b/Moka/16x16@2x/apps/org.remmina.Remmina.png
@@ -1,0 +1,1 @@
+remote-desktop.png

--- a/Moka/22x22/apps/org.remmina.Remmina.png
+++ b/Moka/22x22/apps/org.remmina.Remmina.png
@@ -1,0 +1,1 @@
+remote-desktop.png

--- a/Moka/22x22@2x/apps/org.remmina.Remmina.png
+++ b/Moka/22x22@2x/apps/org.remmina.Remmina.png
@@ -1,0 +1,1 @@
+remote-desktop.png

--- a/Moka/24x24/apps/org.remmina.Remmina.png
+++ b/Moka/24x24/apps/org.remmina.Remmina.png
@@ -1,0 +1,1 @@
+remote-desktop.png

--- a/Moka/24x24@2x/apps/org.remmina.Remmina.png
+++ b/Moka/24x24@2x/apps/org.remmina.Remmina.png
@@ -1,0 +1,1 @@
+remote-desktop.png

--- a/Moka/256x256/apps/org.remmina.Remmina.png
+++ b/Moka/256x256/apps/org.remmina.Remmina.png
@@ -1,0 +1,1 @@
+remote-desktop.png

--- a/Moka/256x256@2x/apps/org.remmina.Remmina.png
+++ b/Moka/256x256@2x/apps/org.remmina.Remmina.png
@@ -1,0 +1,1 @@
+remote-desktop.png

--- a/Moka/32x32/apps/org.remmina.Remmina.png
+++ b/Moka/32x32/apps/org.remmina.Remmina.png
@@ -1,0 +1,1 @@
+remote-desktop.png

--- a/Moka/32x32@2x/apps/org.remmina.Remmina.png
+++ b/Moka/32x32@2x/apps/org.remmina.Remmina.png
@@ -1,0 +1,1 @@
+remote-desktop.png

--- a/Moka/48x48/apps/org.remmina.Remmina.png
+++ b/Moka/48x48/apps/org.remmina.Remmina.png
@@ -1,0 +1,1 @@
+remote-desktop.png

--- a/Moka/48x48@2x/apps/org.remmina.Remmina.png
+++ b/Moka/48x48@2x/apps/org.remmina.Remmina.png
@@ -1,0 +1,1 @@
+remote-desktop.png

--- a/Moka/64x64/apps/org.remmina.Remmina.png
+++ b/Moka/64x64/apps/org.remmina.Remmina.png
@@ -1,0 +1,1 @@
+remote-desktop.png

--- a/Moka/64x64@2x/apps/org.remmina.Remmina.png
+++ b/Moka/64x64@2x/apps/org.remmina.Remmina.png
@@ -1,0 +1,1 @@
+remote-desktop.png

--- a/Moka/96x96/apps/org.remmina.Remmina.png
+++ b/Moka/96x96/apps/org.remmina.Remmina.png
@@ -1,0 +1,1 @@
+remote-desktop.png

--- a/Moka/96x96@2x/apps/org.remmina.Remmina.png
+++ b/Moka/96x96@2x/apps/org.remmina.Remmina.png
@@ -1,0 +1,1 @@
+remote-desktop.png

--- a/src/symlinks/bitmaps/apps.list
+++ b/src/symlinks/bitmaps/apps.list
@@ -667,6 +667,7 @@ remote-desktop.png gnome-remote-desktop.png
 remote-desktop.png NoMachine.png
 remote-desktop.png preferences-desktop-remote-desktop.png
 remote-desktop.png remmina.png
+remote-desktop.png org.remmina.Remmina.png
 samba.png system-config-samba.png
 screenruler.png screenruler-icon.png
 selinux.png setroubleshoot_icon.png


### PR DESCRIPTION
symlinks for new remmina icon name in ubuntu 21.04